### PR TITLE
Add color palette

### DIFF
--- a/src/components/CostEfficiencyAnalysis.jsx
+++ b/src/components/CostEfficiencyAnalysis.jsx
@@ -25,8 +25,8 @@ const CostEfficiencyAnalysis = ({ data }) => {
           const msrp = item["Base MSRP"] || 1; // Avoid division by 0
           return (range / msrp) * 1000;
         }),
-        backgroundColor: "#60a5fa",
-        hoverBackgroundColor: "#3b82f6",
+        backgroundColor: "#2563eb",
+        hoverBackgroundColor: "#1d4ed8",
       },
     ],
   };
@@ -71,7 +71,7 @@ const CostEfficiencyAnalysis = ({ data }) => {
 
   return (
     <div className="bg-white p-6 shadow-lg rounded-lg">
-      <h2 className="text-teal-600 text-xl font-bold mb-4">Cost Efficiency Analysis by Country</h2>
+      <h2 className="text-primary-600 text-xl font-bold mb-4">Cost Efficiency Analysis by Country</h2>
       
       {/* Country Dropdown */}
       <div className="mb-4">
@@ -80,7 +80,7 @@ const CostEfficiencyAnalysis = ({ data }) => {
         </label>
         <select
           id="countryDropdown"
-          className="border-gray-300 rounded-lg shadow-sm focus:border-teal-500 focus:ring-teal-500"
+          className="border-gray-300 rounded-lg shadow-sm focus:border-primary-500 focus:ring-primary-500"
           value={selectedCountry}
           onChange={(e) => setSelectedCountry(e.target.value)}
         >

--- a/src/components/DynamicVehiclePopularity.jsx
+++ b/src/components/DynamicVehiclePopularity.jsx
@@ -50,13 +50,13 @@ console.log("unique",uniqueMakers)
         label: `Number of Vehicles (${selectedMaker})`,
         data: Object.values(modelCounts),
         backgroundColor: [
-          "#008080",
-          "#60a5fa",
+          "#0d9488",
+          "#2563eb",
           "#f97316",
           "#84cc16",
           "#d946ef",
         ],
-        borderColor: ["#005f5f", "#3b82f6", "#c65a09", "#659f11", "#b71ba1"],
+        borderColor: ["#115e59", "#1d4ed8", "#c2410c", "#659f11", "#b71ba1"],
         borderWidth: 1,
       },
     ],
@@ -64,11 +64,11 @@ console.log("unique",uniqueMakers)
 
   return (
     <div className="bg-white p-6 shadow-lg rounded-lg">
-      <h2 className="text-teal-600 text-xl font-bold">
+      <h2 className="text-primary-600 text-xl font-bold">
         Model Distribution by Maker
       </h2>
       <div className="my-4">
-        <label htmlFor="maker" className="text-teal-600 font-semibold">
+        <label htmlFor="maker" className="text-primary-600 font-semibold">
           Select Maker:
         </label>
         <select

--- a/src/components/EVTypeDistribution.jsx
+++ b/src/components/EVTypeDistribution.jsx
@@ -23,15 +23,15 @@ const EVTypeDistribution = ( data ) => {
     datasets: [
       {
         data: Object.values(evTypes),
-        backgroundColor: ["#008080", "#f97316", "#60a5fa"],
-        hoverBackgroundColor: ["#005f5f", "#c65a09", "#3b82f6"],
+        backgroundColor: ["#0d9488", "#f97316", "#2563eb"],
+        hoverBackgroundColor: ["#115e59", "#c2410c", "#1d4ed8"],
       },
     ],
   };
 
   return (
     <div className="bg-white p-6 shadow-lg rounded-lg">
-      <h2 className="text-teal-600 text-xl font-bold mb-4">EV Type Distribution</h2>
+      <h2 className="text-primary-600 text-xl font-bold mb-4">EV Type Distribution</h2>
       <div className="h-full max-h-[500px] flex justify-center">
         <Pie ref={chartRef} data={chartData} options={{ responsive: true }} />
       </div>

--- a/src/components/ElectricVehicleGraph.jsx
+++ b/src/components/ElectricVehicleGraph.jsx
@@ -31,7 +31,7 @@ const ElectricVehicleGraph = (data ) => {
         label: "Electric Vehicles",
         data: Object.values(aggregatedData), // Count of vehicles per year
         fill: false,
-        borderColor: "rgba(75,192,192,1)", // Line color
+        borderColor: "#0d9488", // Line color
         tension: 0.1,
       },
     ],
@@ -39,7 +39,7 @@ const ElectricVehicleGraph = (data ) => {
 
   return (
     <div className="mt-8 bg-white p-6 shadow-lg rounded-lg">
-    <h2 className="text-teal-600 text-xl mb-4">Electric Vehicle Adoption Over Time</h2>
+    <h2 className="text-primary-600 text-xl mb-4">Electric Vehicle Adoption Over Time</h2>
     <div className="h-[500px] flex justify-center" > {/* Set the max height for the chart here */}
       <Line
         data={chartData}

--- a/src/components/EligibilityAnalysis.jsx
+++ b/src/components/EligibilityAnalysis.jsx
@@ -61,8 +61,8 @@ const EligibilityAnalysis = ( data ) => {
           eligibilityData["Eligibility unknown as battery range has not been researched"],
           eligibilityData["Not eligible due to low battery range"]
         ],
-        backgroundColor: ["#60a5fa", "#fca5a5", "#f59e0b"],
-        hoverBackgroundColor: ["#3b82f6", "#f87171", "#d97706"],
+        backgroundColor: ["#2563eb", "#fca5a5", "#f59e0b"],
+        hoverBackgroundColor: ["#1d4ed8", "#f87171", "#d97706"],
       },
     ],
   };
@@ -114,7 +114,7 @@ const EligibilityAnalysis = ( data ) => {
 
   return (
     <div className="bg-white p-6 shadow-lg rounded-lg">
-      <h2 className="text-teal-600 text-xl font-bold">CAFV Eligibility Analysis</h2>
+      <h2 className="text-primary-600 text-xl font-bold">CAFV Eligibility Analysis</h2>
 
       {/* Dropdown for selecting region */}
       <div className="mb-4">
@@ -138,7 +138,7 @@ const EligibilityAnalysis = ( data ) => {
 
       {/* Display eligibility percentage */}
       <div className="mb-4">
-        <h3 className="text-lg font-semibold text-teal-600">Eligibility Percentage:</h3>
+        <h3 className="text-lg font-semibold text-primary-600">Eligibility Percentage:</h3>
         <p>Eligible Vehicles: {eligibilityPercentage.eligible.toFixed(2)}%</p>
         <p>Unknown Eligibility: {eligibilityPercentage.unknown.toFixed(2)}%</p>
         <p>Ineligible Vehicles: {eligibilityPercentage.ineligible.toFixed(2)}%</p>

--- a/src/components/GeographicalInsights.jsx
+++ b/src/components/GeographicalInsights.jsx
@@ -36,8 +36,8 @@ const GeographicalInsights = (data) => {
       {
         label: "Vehicle Count",
         data: Object.values(cityData), // Counts for each city
-        backgroundColor: "#60a5fa",
-        hoverBackgroundColor: "#3b82f6",
+        backgroundColor: "#2563eb",
+        hoverBackgroundColor: "#1d4ed8",
       },
     ],
   };
@@ -77,7 +77,7 @@ const GeographicalInsights = (data) => {
 
   return (
     <div className="bg-white p-6 shadow-lg rounded-lg">
-      <h2 className="text-teal-600 text-xl font-bold">Geographical Vehicle Distribution</h2>
+      <h2 className="text-primary-600 text-xl font-bold">Geographical Vehicle Distribution</h2>
       
       {/* Dropdown for selecting county */}
       <div className="mb-4">

--- a/src/components/KPISummary.jsx
+++ b/src/components/KPISummary.jsx
@@ -19,25 +19,25 @@ const KPISummary = ( data ) => {
       {/* Total Vehicles */}
       <div className="bg-white p-4 shadow rounded-lg text-center">
         <h3 className="text-xl font-semibold">Total Vehicles</h3>
-        <CountUp start={0} end={totalVehicles} duration={2} separator="," className="text-2xl font-bold text-teal-600" />
+        <CountUp start={0} end={totalVehicles} duration={2} separator="," className="text-2xl font-bold text-primary-600" />
       </div>
 
       {/* CAFV Eligible */}
       <div className="bg-white p-4 shadow rounded-lg text-center">
         <h3 className="text-xl font-semibold">CAFV Eligible (%)</h3>
-        <CountUp start={0} end={((cafvEligible / totalVehicles) * 100).toFixed(1)} duration={2} decimals={1} className="text-2xl font-bold text-teal-600" />
+        <CountUp start={0} end={((cafvEligible / totalVehicles) * 100).toFixed(1)} duration={2} decimals={1} className="text-2xl font-bold text-primary-600" />
       </div>
 
       {/* Average MSRP */}
       <div className="bg-white p-4 shadow rounded-lg text-center">
         <h3 className="text-xl font-semibold">Average MSRP</h3>
-        <CountUp start={0} end={avgMsrp} duration={2} decimals={2} prefix="$" className="text-2xl font-bold text-teal-600" />
+        <CountUp start={0} end={avgMsrp} duration={2} decimals={2} prefix="$" className="text-2xl font-bold text-primary-600" />
       </div>
 
       {/* Average Electric Range */}
       <div className="bg-white p-4 shadow rounded-lg text-center">
         <h3 className="text-xl font-semibold">Average Electric Range</h3>
-        <CountUp start={0} end={avgRange} duration={2} decimals={1} suffix=" miles" className="text-2xl font-bold text-teal-600" />
+        <CountUp start={0} end={avgRange} duration={2} decimals={1} suffix=" miles" className="text-2xl font-bold text-primary-600" />
       </div>
     </div>
   );

--- a/src/components/MakerBasedAnalysis.jsx
+++ b/src/components/MakerBasedAnalysis.jsx
@@ -55,13 +55,13 @@ const MakerBasedAnalysis = (data) => {
         label: `Number of Vehicles (${selectedMaker})`,
         data: Object.values(modelCounts),
         backgroundColor: [
-          "#008080",
-          "#60a5fa",
+          "#0d9488",
+          "#2563eb",
           "#f97316",
           "#84cc16",
           "#d946ef",
         ],
-        borderColor: ["#005f5f", "#3b82f6", "#c65a09", "#659f11", "#b71ba1"],
+        borderColor: ["#115e59", "#1d4ed8", "#c2410c", "#659f11", "#b71ba1"],
         borderWidth: 1,
       },
     ],
@@ -84,8 +84,8 @@ const MakerBasedAnalysis = (data) => {
           const msrp = vehicle["Base MSRP"] || 1; // Avoid division by 0
           return (range / msrp) * 1000;
         }),
-        backgroundColor: "#60a5fa",
-        hoverBackgroundColor: "#3b82f6",
+        backgroundColor: "#2563eb",
+        hoverBackgroundColor: "#1d4ed8",
       },
     ],
   };
@@ -168,9 +168,9 @@ const MakerBasedAnalysis = (data) => {
 
   return (
     <div className="bg-white p-6 shadow-lg rounded-lg">
-      <h2 className="text-teal-600 text-xl font-bold">Vehicle Data Insights by Maker</h2>
+      <h2 className="text-primary-600 text-xl font-bold">Vehicle Data Insights by Maker</h2>
       <div className="my-4">
-        <label htmlFor="maker" className="text-teal-600 font-semibold">
+        <label htmlFor="maker" className="text-primary-600 font-semibold">
           Select Maker:
         </label>
         <select
@@ -191,14 +191,14 @@ const MakerBasedAnalysis = (data) => {
       {/* Buttons to switch between insights */}
       <div className="my-4">
         <button
-          className={`p-2 m-2 border rounded ${selectedInsight === "bar" ? "bg-teal-600 text-white" : "bg-white text-teal-600"}`}
+          className={`p-2 m-2 border rounded ${selectedInsight === "bar" ? "bg-primary-600 text-white" : "bg-white text-primary-600"}`}
           onClick={() => setSelectedInsight("bar")}
         >
           Model Distribution by Maker
         </button>
       
         <button
-          className={`p-2 m-2 border rounded ${selectedInsight === "range" ? "bg-teal-600 text-white" : "bg-white text-teal-600"}`}
+          className={`p-2 m-2 border rounded ${selectedInsight === "range" ? "bg-primary-600 text-white" : "bg-white text-primary-600"}`}
           onClick={() => setSelectedInsight("range")}
         >
           Range per $1,000 MSRP

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -28,7 +28,7 @@ const Dashboard = () => {
   return (
     <div className="bg-gray-100 min-h-screen text-black flex flex-col">
 
-      <header className="bg-gradient-to-r from-teal-500 to-cyan-600 text-white p-6 shadow-lg">
+      <header className="bg-gradient-to-r from-primary-500 to-cyan-600 text-white p-6 shadow-lg">
         <h1 className="text-3xl font-bold text-center tracking-wide">Electric Vehicle Dashboard</h1>
       </header>
 
@@ -42,42 +42,42 @@ const Dashboard = () => {
           <div className="flex justify-start space-x-4">
             <button
               onClick={() => handleTabChange("EVGraph")}
-              className={`text-xl font-semibold px-4 py-2 rounded-lg transition-colors duration-200 ${activeTab === "EVGraph" ? "bg-teal-600 text-white" : "bg-white text-teal-600 hover:bg-teal-50"}`}
+              className={`text-xl font-semibold px-4 py-2 rounded-lg transition-colors duration-200 ${activeTab === "EVGraph" ? "bg-primary-600 text-white" : "bg-white text-primary-600 hover:bg-primary-50"}`}
             >
               <FaChartBar size={20} className="mr-2" />
               Electric Vehicle Graph
             </button>
             <button
               onClick={() => handleTabChange("EVTypeDistribution")}
-              className={`text-xl font-semibold px-4 py-2 rounded-lg transition-colors duration-200 ${activeTab === "EVTypeDistribution" ? "bg-teal-600 text-white" : "bg-white text-teal-600 hover:bg-teal-50"}`}
+              className={`text-xl font-semibold px-4 py-2 rounded-lg transition-colors duration-200 ${activeTab === "EVTypeDistribution" ? "bg-primary-600 text-white" : "bg-white text-primary-600 hover:bg-primary-50"}`}
             >
               <FaCar size={20} className="mr-2" />
               EV Type Distribution
             </button>
             <button
               onClick={() => handleTabChange("TopMakesModels")}
-              className={`text-xl font-semibold px-4 py-2 rounded-lg transition-colors duration-200 ${activeTab === "TopMakesModels" ? "bg-teal-600 text-white" : "bg-white text-teal-600 hover:bg-teal-50"}`}
+              className={`text-xl font-semibold px-4 py-2 rounded-lg transition-colors duration-200 ${activeTab === "TopMakesModels" ? "bg-primary-600 text-white" : "bg-white text-primary-600 hover:bg-primary-50"}`}
             >
               <FaIndustry size={20} className="mr-2" />
               Top Makes and Models
             </button>
             <button
               onClick={() => handleTabChange("CAFVEligibility")}
-              className={`text-xl font-semibold px-4 py-2 rounded-lg transition-colors duration-200 ${activeTab === "CAFVEligibility" ? "bg-teal-600 text-white" : "bg-white text-teal-600 hover:bg-teal-50"}`}
+              className={`text-xl font-semibold px-4 py-2 rounded-lg transition-colors duration-200 ${activeTab === "CAFVEligibility" ? "bg-primary-600 text-white" : "bg-white text-primary-600 hover:bg-primary-50"}`}
             >
               <FaRegLightbulb size={20} className="mr-2" />
               CAFV Eligibility Analysis
             </button>
             <button
               onClick={() => handleTabChange("GeographicalDistribution")}
-              className={`text-xl font-semibold px-4 py-2 rounded-lg transition-colors duration-200 ${activeTab === "GeographicalDistribution" ? "bg-teal-600 text-white" : "bg-white text-teal-600 hover:bg-teal-50"}`}
+              className={`text-xl font-semibold px-4 py-2 rounded-lg transition-colors duration-200 ${activeTab === "GeographicalDistribution" ? "bg-primary-600 text-white" : "bg-white text-primary-600 hover:bg-primary-50"}`}
             >
               <FaMapMarkedAlt size={20} className="mr-2" />
               Geographical Distribution
             </button>
             <button
               onClick={() => handleTabChange("MakerBasedAnalysis")}
-              className={`text-xl font-semibold px-4 py-2 rounded-lg transition-colors duration-200 ${activeTab === "MakerBasedAnalysis" ? "bg-teal-600 text-white" : "bg-white text-teal-600 hover:bg-teal-50"}`}
+              className={`text-xl font-semibold px-4 py-2 rounded-lg transition-colors duration-200 ${activeTab === "MakerBasedAnalysis" ? "bg-primary-600 text-white" : "bg-white text-primary-600 hover:bg-primary-50"}`}
             >
               <FaIndustry size={20} className="mr-2" />
               Maker Based Analysis
@@ -98,7 +98,7 @@ const Dashboard = () => {
         </section>
       </main>
 
-      <footer className="bg-teal-600 text-white p-4 text-center">
+      <footer className="bg-primary-600 text-white p-4 text-center">
         <p>© 2025 Electric Vehicle Dashboard</p>
       </footer>
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,9 +7,27 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Inter', 'sans-serif'], 
+        sans: ['Inter', 'sans-serif'],
+      },
+      colors: {
+        primary: {
+          50: '#f0fdfa',
+          500: '#14b8a6',
+          600: '#0d9488',
+        },
+        secondary: {
+          50: '#eff6ff',
+          500: '#3b82f6',
+          600: '#2563eb',
+        },
+        accent: {
+          50: '#fff7ed',
+          500: '#f97316',
+          600: '#ea580c',
+        },
       },
     },
   },
   plugins: [],
 }
+


### PR DESCRIPTION
## Summary
- extend Tailwind with custom primary, secondary and accent colors
- update dashboard buttons and KPI summaries to use the palette
- switch chart series colours to palette values

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685cda0e01bc8324914aca1c2340a338